### PR TITLE
Use inline asm, try to detect support in build.rs to avoid MSRV change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,86 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").expect("No `CARGO_CFG_TARGET_ARCH`?");
+    if "x86" == arch {
+        return;
+    }
+    let feats = std::env::var("CARGO_CFG_TARGET_FEATURES").unwrap_or_default();
+    if feats.split(",").any(|s| s == "sse") {
+        return;
+    }
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if env == "sgx" {
+        return;
+    }
+    if let Some((maj, min)) = rustc_ver() {
+        if maj >= 1 || min >= 59 {
+            println!("cargo:rustc-cfg=core_detect_can_have_a_little_asm_as_a_treat");
+        }
+    }
+}
+
+fn rustc_ver() -> Option<(u32, u32)> {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    match std::process::Command::new(&rustc).arg("-V").output() {
+        Err(e) => {
+            eprintln!("OS error running `{:?} -V`: {:?}", rustc, e);
+            None
+        }
+        Ok(std::process::Output {
+            status,
+            stdout,
+            stderr,
+            ..
+        }) => {
+            let stdout = String::from_utf8_lossy(&stdout);
+            let stderr = String::from_utf8_lossy(&stderr);
+            if !status.success() {
+                eprintln!(
+                    "Command `{:?} -V` exited with non-success code {:?}\n##stdout:```\n{}\n```\n##stderr:```\n{}\n```",
+                    rustc, status, stdout, stderr,
+                );
+                println!(
+                    "cargo:warning=Got {:?} from `{:?} -V`, see stderr log for more details",
+                    status, rustc
+                );
+            }
+            let stdout = stdout.trim();
+            let line_at_version = if stdout.starts_with("rustc ") {
+                stdout.get(6..)
+            } else {
+                let pos = stdout.find("rustc 1.").or_else(|| stdout.find("rustc "))?;
+                stdout.get((pos + 6)..)
+            };
+            match line_at_version {
+                None => {
+                    println!(
+                        "cargo:warning=Unable to find where the rustc version starts in {:?}",
+                        stdout
+                    );
+                    None
+                }
+                Some(line) => {
+                    let pos = line
+                        .find(|c: char| !(c == '.' || c.is_digit(10)))
+                        .unwrap_or(line.len());
+                    let ver = line.get(..pos)?;
+                    let mut nums = dbg!(ver.split('.'));
+                    let maj = nums.next()?;
+                    let min = nums.next()?;
+
+                    match (maj.parse::<u32>(), min.parse::<u32>()) {
+                        (Ok(maj), Ok(min)) => Some((maj, min)),
+                        tup => {
+                            println!(
+                                "cargo:warning=failed to parse output of rustc -V. \
+                                 result={:?}, input={:?} (full input: {:?})",
+                                tup, line, stdout,
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,6 +17,12 @@ const fn test_bit(x: u64, bit: u32) -> bool {
     x & (1 << bit) != 0
 }
 
+/// Unset the `bit of `x`.
+#[inline]
+const fn unset_bit(x: u64, bit: u32) -> u64 {
+    x & !(1 << bit)
+}
+
 /// Maximum number of features that can be cached.
 const CACHE_CAPACITY: u32 = 62;
 
@@ -53,6 +59,12 @@ impl Initializer {
         );
         let v = self.0;
         self.0 = set_bit(v, bit);
+    }
+    /// Sets the `bit` of the cache.
+    #[inline]
+    pub(crate) fn unset(&mut self, bit: u32) {
+        let v = self.0;
+        self.0 = unset_bit(v, bit);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,65 +27,8 @@
 //!
 //! (In the future, this crate may provide another macro which returns false in
 //! these cases instead, and supports testing multiple features simultaneously).
-//!
-//! # Caveats
-//! The `cpuid` instruction doesn't exist on all x86 machines, it was added
-//! around 1994. (It's also not available on SGX, but this doesn't cause any
-//! issues since we can check that with `cfg(target_env = "sgx")`).
-//!
-//! If you run `cpuid` on a machine older than that, it causes an illegal
-//! instruction fault (SIGILL). Unfortunately, there's no good stable way to
-//! reliably determine if `cpuid` will fault in stable rust: A
-//! [`core::arch::x86::has_cpuid`](https://doc.rust-lang.org/nightly/core/arch/x86/fn.has_cpuid.html)
-//! function exists, but didn't stabilize with the rest of `core::arch::x86`,
-//! and the only way to implement it ourselves is with inline asm, which... is
-//! also still unstable.
-//!
-//! For what it's worth, it's actually pretty uncommon that we'd need to call
-//! `has_cpuid` on common rust targets, since we perform the following compile
-//! time checks:
-//! - We never have cpuid on `target_env = "sgx"` (as mentioned).
-//! - We always have cpuid on `target_arch = "x86_64"`.
-//! - And we always have cpuid if `target_feature = "sse"` (which covers the
-//!   `i686-*` targets).
-//!
-//! Unfortunately, if none of those applies... we don't know if calling CPUID
-//! will crash the process. This library has a few ways it can handle this:
-//!
-//! 1. Cautiously (the default): In this mode, we conceptually swap `has_cpuid`
-//!    out with a function that always returns false. That is: we never call it
-//!    unless we're sure it wont crash the process.
-//!
-//! 2. Recklessly (`feature = "assume_has_cpuid"`): This is essentially the
-//!    opposite of the last one — assume `has_cpuid` would have returned true,
-//!    and call `cpuid` anyway.
-//!
-//!     In practice, this should be fine. These machines are rare now (they're
-//!     over 30 years old...), and pretty only are common through QEMU, and even
-//!     then, usually after a misconfiguration.
-//!
-//!     If you do happen to run the instruction, the process crashes, but in a
-//!     controlled manner — Executing an illegal instruction to tringger a
-//!     SIGILL is what `core::intrinsics::abort` does on x86, so it's not
-//!     dangerous or anything.
-//!
-//! 3. Using unstable nightly features (`feature = "unstable_has_cpuid"`): This
-//!    approach requires a nightly compiler, but has no other major downsides,
-//!    besides the fact that the `has_cpuid` function could vanish at any time.
-//!
-//! Eventually, inline asm will stabilize and we can solve this problem more
-//! cleanly.
 #![no_std]
 #![allow(dead_code)]
-#![cfg_attr(
-    all(
-        target_arch = "x86",
-        not(target_env = "sgx"),
-        not(target_feature = "sse"),
-        feature = "unstable_has_cpuid",
-    ),
-    feature(stdsimd)
-)]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Fixes #3.

I'm not sure if the version detection is worth it. I kind of think its not and this should just bump MSRV. Most of this I wrote longer ago when I cared about MSRV much more, but never managed to get it up.

This also updates the detection for changes in the stdlib since then.